### PR TITLE
Effectively call generator-function for real-generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: common-lisp
 
+sudo: required
 env:
   matrix:
     - LISP=abcl

--- a/src/generators.lisp
+++ b/src/generators.lisp
@@ -235,7 +235,7 @@
   (funcall (generator-function generator)))
 
 (defmethod generate ((generator real-generator))
-  (- (random (float (* 2 *size*))) *size*))
+  (funcall (generator-function generator)))
 
 (defmethod generate ((generator guard-generator))
   (let ((try (generate (sub-generator generator))))

--- a/test/randomized-tests.lisp
+++ b/test/randomized-tests.lisp
@@ -34,6 +34,27 @@
               do
                 (is (<= (- *size*) (generate generator) *size*)))))))
 
+(deftest test-real-generate ()
+  (loop for size in (list 10 20 50 300)
+     do
+       (let ((*size* size))
+         (let ((generator (generator (real * 2))))
+           (loop for i from 1 to 100
+              do
+                (is (<= (- *size*) (generate generator) 2))))
+         (let ((generator (generator (real -2 *))))
+           (loop for i from 1 to 100
+              do
+                (is (<= -2 (generate generator) *size*))))
+         (let ((generator (generator (real -2 2))))
+           (loop for i from 1 to 100
+              do
+                (is (<= -2 (generate generator) 2))))
+         (let ((generator (generator (real))))
+           (loop for i from 1 to 100
+              do
+                (is (<= (- *size*) (generate generator) *size*)))))))
+
 ;;;; Shrink results of generators
 
 (deftest test-int-generate-shrink ()


### PR DESCRIPTION
Hi @DalekBaldwin,

I tried to generate some real numbers between 0 and 1 with

``` lisp
(generate (generator (real 0 1)))
```

but didn't get the desired results. After some research I realized that the `generator-function` on `real-generator` wasn't called appropriately. So this PR aims to fix that. :+1: 

Best,
Sebastian
