### PR TITLE
Added the macro with-generators.

### DIFF
--- a/check-it.asd
+++ b/check-it.asd
@@ -25,7 +25,7 @@
                          (:file "shrink")
                          (:file "check-it"))
             :serial t))
-  :depends-on (:alexandria :closer-mop :optima)
+  :depends-on (:alexandria :closer-mop :optima :hu.dwim.walker)
   :in-order-to ((test-op (load-op :check-it-test)))
   :perform (test-op :after (op c)
                     (funcall

--- a/check-it.asd
+++ b/check-it.asd
@@ -23,9 +23,10 @@
                          (:file "generators")
                          (:file "regenerate")
                          (:file "shrink")
-                         (:file "check-it"))
+                         (:file "check-it")
+                         (:file "walker"))
             :serial t))
-  :depends-on (:alexandria :closer-mop :optima :hu.dwim.walker)
+  :depends-on (:alexandria :closer-mop :optima :hu.dwim.walker :clunit)
   :in-order-to ((test-op (load-op :check-it-test)))
   :perform (test-op :after (op c)
                     (funcall

--- a/src/check-it.lisp
+++ b/src/check-it.lisp
@@ -170,67 +170,6 @@
                       (return-from trial-run nil))))))))
       (return-from trial-run t))))
 
-(defun test-group (test generator n)
-  "Test a group of assertions. TEST is a function that represents the
-   group. It should be called with the generated values and a number
-   which specifies which assertions to run. If the number is zero run all
-   of the assertions. If the number is less than N, then it designates a
-   specific assertion to run."
-  (let ((error-reporting-test
-         (wrap-test-for-error-reporting test))
-        (shrink-test
-         (wrap-test-for-shrinking test))
-        ;; This needs to be bound to true. Otherwise when we resignal
-        ;; the error, the code that catches it will invoke the
-        ;; skip-test restart. It would normally invoke the
-        ;; skip-assertion-restart but since the stack has already been
-        ;; unwound a bit, that point has already been unwound.
-        (clunit::*use-debugger* t)
-        (clunit::*report-progress* nil))
-    (let ((*random-state* (make-random-state t)))
-      (loop for test-num from 1 to n do
-        (loop named trial-run
-              finally (clunit::signal-assertion :pass)
-              repeat *num-trials* do
-          (generate generator)
-           ;; produce readable representation before anybody mutates this value
-          (let ((stringified-value (format nil "~S" (cached-value generator)))
-                (result (funcall error-reporting-test (cached-value generator) test-num)))
-            (flet ((do-shrink ()
-                     (let ((shrunk (shrink generator (rcurry shrink-test test-num))))
-                       (format *check-it-output* "~&Shrunken failure case: ~A~%" shrunk)
-                       (format *check-it-output* "~&Testing all assertions that fail the shrunken case:~%")
-                       (handler-case
-                         (handler-bind ((clunit::assertion-failed (compose #'continue #'print-assertion))
-                                        (clunit::assertion-passed #'continue))
-                           (funcall test shrunk 0))
-                         (error (c)
-                           (format *check-it-output*
-                                   "~&Error ~A signaled. Aborting rest of test.~%"
-                                   c)))
-                       (terpri *check-it-output*))))
-              (typecase result
-                (clunit::assertion-failed
-                 ;; Resignal the condition so other places can use it
-                 ;; to log information. Since we are using signal and
-                 ;; not error, the debugger will not be entered if it
-                 ;; isn't handled.
-                 (signal result)
-                 (format *check-it-output* "~&Failed case: ~A~%" stringified-value)
-                 (print-assertion result)
-                 (do-shrink)
-                 (return-from trial-run nil))
-                (reified-error
-                 (format *check-it-output*
-                         "~&Test signaled error ~A with arg ~A~%"
-                         (wrapped-error result)
-                         stringified-value)
-                 (do-shrink)
-                 (return-from trial-run nil))))))))))
-
-(defun print-assertion (c)
-  (format *check-it-output* "~&Assertion ~A failed.~%" (slot-value c 'clunit::expression)))
-
 (defmacro check-it (generator test
                     &key
                       examples

--- a/src/check-it.lisp
+++ b/src/check-it.lisp
@@ -178,24 +178,3 @@
               ,@(when random-state-supplied `(:random-state ,random-state))
               ,@(when regression-id-supplied `(:regression-id ',regression-id))
               ,@(when regression-file-supplied `(:regression-file ,regression-file))))
-
-(defmacro with-generators (bindings &body body)
-  "Convience macro for binding variables to generators and running
-   tests with them."
-  ;; I need to come up with better names for these.
-  (with-gensyms (ggen ggarg gargs)
-    (loop for (symbol generator) in bindings
-          collect generator into generators
-          collect symbol into symbols
-          finally (return
-                    `(let ((,ggen (generator (tuple ,@generators))))
-                       (macrolet ((check-that (expr &rest ,gargs)
-                                    (let ((,ggarg (gensym "ARG")))
-                                      `(apply #'check-it%
-                                              ',expr
-                                              ,',ggen
-                                              (lambda (,,ggarg)
-                                                (destructuring-bind ,',symbols ,,ggarg
-                                                  ,@expr))
-                                              (list ,@,gargs)))))
-                         ,@body))))))

--- a/src/check-it.lisp
+++ b/src/check-it.lisp
@@ -54,18 +54,18 @@
 
 (defun wrap-test-for-error-reporting (test)
   "Return a function capturing unhandled errors in TEST as data."
-  (lambda (arg)
-    (handler-case
-        (funcall test arg)
-      (error (c)
-        (make-instance 'reified-error :wrapped-error c)))))
+  (lambda (&rest args)
+    (handler-case (progn (apply test args) t)
+      (clunit::assertion-failed (c) c)
+      (error (c) (make-instance 'reified-error :wrapped-error c)))))
 
 (defun wrap-test-for-shrinking (test)
   "Return a function treating unhandled errors in TEST as failures."
-  (lambda (arg)
+  (lambda (&rest args)
     (handler-case
-        (funcall test arg)
-      (error () nil))))
+        (apply test args)
+      (error () nil)
+      (clunit::assertion-failed () nil))))
 
 (defun check-it% (test-form generator test
                   &key
@@ -163,6 +163,63 @@
                                            stringified-value))
                       (return-from trial-run nil))))))))
       (return-from trial-run t))))
+
+(defun test-group (test generator n)
+  "Test a group of assertions. TEST is a function that represents the
+   group. It should be called with the generated values and a number
+   which specifies which assertions to run. If the number is zero run all
+   of the assertions. If the number is less than N, then it designates a
+   specific assertion to run."
+  (let ((error-reporting-test
+         (wrap-test-for-error-reporting test))
+        (shrink-test
+         (wrap-test-for-shrinking test))
+        ;; This needs to be bound to true. Otherwise when we resignal
+        ;; the error, the code that catches it will invoke the
+        ;; skip-test restart. It would normally invoke the
+        ;; skip-assertion-restart but since the stack has already been
+        ;; unwound a bit, that point has already been unwound.
+        (clunit::*use-debugger* t)
+        (clunit::*report-progress* nil))
+    (let ((*random-state* (make-random-state t)))
+      (loop for test-num from 1 to n do
+        (loop named trial-run repeat *num-trials* do
+          (generate generator)
+           ;; produce readable representation before anybody mutates this value
+          (let ((stringified-value (format nil "~S" (cached-value generator)))
+                (result (funcall error-reporting-test (cached-value generator) test-num)))
+            (flet ((do-shrink ()
+                     (let ((shrunk (shrink generator (rcurry shrink-test test-num))))
+                       (format *check-it-output* "~&Shrunken failure case: ~A~%" shrunk)
+                       (format *check-it-output* "~&Testing all assertions that fail this case:~%")
+                       (handler-case
+                         (handler-bind ((clunit::assertion-failed (compose #'continue #'print-assertion)))
+                           (funcall test shrunk 0))
+                         (error (c)
+                           (format *check-it-output*
+                                   "~&Error ~A signaled. Aborting rest of test.~%"
+                                   c)))
+                       (terpri))))
+              (typecase result
+                (clunit::assertion-failed
+                 ;; Resignal the condition so other places can use it
+                 ;; to log information. Since we are using signal and
+                 ;; not error, the debugger will not be entered if it
+                 ;; isn't handled.
+                 (signal result)
+                 (print-assertion result)
+                 (do-shrink)
+                 (return-from trial-run nil))
+                (reified-error
+                 (format *check-it-output*
+                         "~&Test signaled error ~A with arg ~A~%"
+                         (wrapped-error result)
+                         stringified-value)
+                 (do-shrink)
+                 (return-from trial-run nil))))))))))
+
+(defun print-assertion (c)
+  (format *check-it-output* "~&Assertion ~A failed.~%" (slot-value c 'clunit::expression)))
 
 (defmacro check-it (generator test
                     &key

--- a/src/check-it.lisp
+++ b/src/check-it.lisp
@@ -199,7 +199,7 @@
             (flet ((do-shrink ()
                      (let ((shrunk (shrink generator (rcurry shrink-test test-num))))
                        (format *check-it-output* "~&Shrunken failure case: ~A~%" shrunk)
-                       (format *check-it-output* "~&Testing all assertions that fail this case:~%")
+                       (format *check-it-output* "~&Testing all assertions that fail the shrunken case:~%")
                        (handler-case
                          (handler-bind ((clunit::assertion-failed (compose #'continue #'print-assertion))
                                         (clunit::assertion-passed #'continue))
@@ -216,6 +216,7 @@
                  ;; not error, the debugger will not be entered if it
                  ;; isn't handled.
                  (signal result)
+                 (format *check-it-output* "~&Failed case: ~A~%" stringified-value)
                  (print-assertion result)
                  (do-shrink)
                  (return-from trial-run nil))

--- a/src/clunit.lisp
+++ b/src/clunit.lisp
@@ -1,0 +1,66 @@
+(in-package :check-it)
+
+(defun test-group (test generator n)
+  "Test a group of assertions. TEST is a function that represents the
+   group. It should be called with the generated values and a number
+   which specifies which assertions to run. If the number is zero run all
+   of the assertions. If the number is less than N, then it designates a
+   specific assertion to run."
+  (let ((error-reporting-test
+         (wrap-test-for-error-reporting test))
+        (shrink-test
+         (wrap-test-for-shrinking test)))
+    (let ((*random-state* (make-random-state t)))
+      (loop for test-num from 1 to n do
+        (loop named trial-run
+              finally (clunit::signal-assertion :pass)
+              repeat *num-trials* do
+          (generate generator)
+           ;; produce readable representation before anybody mutates this value
+          (let ((stringified-value (format nil "~S" (cached-value generator)))
+                (result (funcall error-reporting-test (cached-value generator) test-num)))
+            (flet ((do-shrink ()
+                     (let ((shrunk (shrink generator (rcurry shrink-test test-num))))
+                       (format *check-it-output* "~&Shrunken failure case: ~A~%" shrunk)
+                       (format *check-it-output* "~&Testing all assertions that fail the shrunken case:~%")
+                       (handler-case
+                         (handler-bind ((clunit::assertion-failed (compose #'continue #'print-assertion))
+                                        (clunit::assertion-passed #'continue))
+                           (funcall test shrunk 0))
+                         (error (c)
+                           (format *check-it-output*
+                                   "~&Error ~A signaled. Aborting rest of test.~%"
+                                   c)))
+                       (terpri *check-it-output*))))
+              (typecase result
+                (clunit::assertion-failed
+                 ;; Resignal the condition so other places can use it
+                 ;; to log information. Since we are using signal and
+                 ;; not error, the debugger will not be entered if it
+                 ;; isn't handled.
+                 (signal result)
+                 (print-assertion result)
+                 (format *check-it-output* "~&Failed case: ~A~%" stringified-value)
+                 (do-shrink)
+                 (return-from trial-run nil))
+                (reified-error
+                 (format *check-it-output*
+                         "~&Test signaled error ~A with arg ~A~%"
+                         (wrapped-error result)
+                         stringified-value)
+                 (do-shrink)
+                 (return-from trial-run nil))))))))))
+
+(defun print-assertion (c)
+  (format *check-it-output* "~&Assertion ~A failed.~%" (slot-value c 'clunit::expression)))
+
+;; use-debugger need to be bound to true. Otherwise when we resignal
+;; the error, the code that catches it will invoke the skip-test
+;; restart. It would normally invoke the skip-assertion-restart but
+;; since the stack has already been unwound a bit, that point has
+;; already been unwound.
+(defun run-test (test &rest args)
+  (apply #'clunit:run-test test :use-debugger t :report-progress nil args))
+
+(defun run-suite (suite &rest args)
+  (apply #'clunit:run-suite suite :use-debugger t :report-progress nil args))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -56,7 +56,8 @@
            #:*check-it-output*
            #:register-package-regression-file
            #:regression-case
-           #:check-it))
+           #:check-it
+           #:with-generators))
 
 (in-package :check-it)
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -56,7 +56,8 @@
            #:register-package-regression-file
            #:regression-case
            #:check-it
-           #:with-generators))
+           #:with-tests
+           #:check-that))
 
 (in-package :check-it)
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -2,6 +2,7 @@
 
 (defpackage :check-it
   (:use :cl :alexandria :optima :hu.dwim.walker :hu.dwim.def :contextl :clunit)
+  (:shadow #:run-test #:run-suite)
   (:export #:shrink
            #:shrink-and-trap-errors
 
@@ -14,7 +15,7 @@
 
            #:generator
            #:generate
-           
+
            #:regenerate
 
            #:int-generator
@@ -48,7 +49,7 @@
 
            #:def-generator
            #:def-genex-macro
-           
+
            #:wrap-test-for-error-reporting
            #:wrap-test-for-shrinking
 
@@ -57,7 +58,10 @@
            #:regression-case
            #:check-it
            #:with-tests
-           #:check-that))
+           #:check-that
+
+           #:deftest
+           #:defsuite))
 
 (in-package :check-it)
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -60,8 +60,8 @@
            #:with-tests
            #:check-that
 
-           #:deftest
-           #:defsuite))
+           #:run-test
+           #:run-suite))
 
 (in-package :check-it)
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,7 +1,7 @@
 (in-package :cl-user)
 
 (defpackage :check-it
-  (:use :cl :alexandria :optima :hu.dwim.walker :hu.dwim.def :contextl)
+  (:use :cl :alexandria :optima :hu.dwim.walker :hu.dwim.def :contextl :clunit)
   (:export #:shrink
            #:shrink-and-trap-errors
 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,7 +1,7 @@
 (in-package :cl-user)
 
 (defpackage :check-it
-  (:use :cl :alexandria :optima)
+  (:use :cl :alexandria :optima :hu.dwim.walker :hu.dwim.def :contextl)
   (:export #:shrink
            #:shrink-and-trap-errors
 
@@ -43,7 +43,6 @@
            #:element
            #:elements
            #:guard
-           #:constructor
            #:slot-names
            #:slot-generators
 

--- a/src/walker.lisp
+++ b/src/walker.lisp
@@ -15,10 +15,12 @@
 (def (walker :in with-tests) generator
   (with-form-object (form 'generator-form -parent-)
     (setf (expr-of form)
-          ;; All of the nested generators should be left alone.
+          ;; All of the nested generators should be left alone so we
+          ;; deactivate the with-tests layer.
           (with-inactive-layers (with-tests)
             (hu.dwim.walker::recurse -form-)))))
 
+;; Replace a generator form with the gensym that will be bound to it.
 (def unwalker generator-form (gensym)
   gensym)
 
@@ -26,19 +28,18 @@
   (with-form-object (form 'check-that-form -parent-)
     (setf (value-of form) (hu.dwim.walker::recurse (cadr -form-)))))
 
+;; Any check-that should immediately return its value from the
+;; test-block since we are only checking one check-that at a time.
 (def unwalker check-that-form (value)
   `(return-from ,*test-block* ,(unwalk-form value)))
 
-;; Substitute every check-that-form that remains with the gensym used
-;; for it.
 (def macro with-tests (&body body &environment env)
-  (process-body `(progn ,@body) (make-walk-environment env)))
-
-(def function process-body (body &optional env)
   (with-active-layers (with-tests)
-    (let* ((ast (walk-form body :environment env))
+    (let* ((ast (walk-form `(progn ,@body) :environment (make-walk-environment env)))
+           ;; Collect-variable-references is poorly named. It makes it
+           ;; possible to obtain all of the ast nodes of a given type.
            (check-that-forms (collect-variable-references ast :type 'check-that-form))
-           (generator-forms (collect-variable-references ast :type 'generator-form))
+           (generator-forms  (collect-variable-references ast :type 'generator-form))
            (gensyms (mapcar #'gensym-of generator-forms))
            (generator `(generator (tuple ,@(mapcar (compose #'unwalk-form #'expr-of) generator-forms)))))
       (duplicate ast generator check-that-forms gensyms))))
@@ -46,20 +47,25 @@
 (def function duplicate (ast generator check-that-forms gensyms)
   "Duplicates AST N times, with only a single, but different
    check-that in each one. GENERATOR is the generator expression that
-   should be used for to generate all of the values. GENSYMS are the
+   should be used to generate all of the values. GENSYMS are the
    symbols the values returned by GENERATOR should be bound to."
   (once-only (generator)
-    `(progn ,@(loop with gargs = (gensym "ARGS")
-                    for check-that-form in check-that-forms
-                    collect `(check-it% ',(source-of check-that-form)
-                                        ,generator
-                                        (lambda (,gargs)
-                                          (block ,*test-block*
-                                            (destructuring-bind ,gensyms ,gargs
-                                              (declare (ignorable ,@gensyms))
-                                              ,(unwalk-form (substitute-ast-if
-                                                             (walk-form nil)
-                                                             (lambda (form)
-                                                               (and (typep form 'check-that-form)
-                                                                    (not (eq check-that-form form))))
-                                                             ast))))))))))
+    `(progn
+       ,@(loop for check-that-form in check-that-forms
+               for gargs = (gensym "ARGS")
+               collect `(check-it% ',(source-of (value-of check-that-form))
+                                   ,generator
+                                   (lambda (,gargs)
+                                     (block ,*test-block*
+                                       (destructuring-bind ,gensyms ,gargs
+                                         (declare (ignorable ,@gensyms))
+                                         ;; Substitute nil for all of
+                                         ;; the check-that forms that
+                                         ;; are not eq to the one form
+                                         ;; we are leaving.
+                                         ,(unwalk-form (substitute-ast-if
+                                                        (walk-form nil)
+                                                        (lambda (form)
+                                                          (and (typep form 'check-that-form)
+                                                               (not (eq check-that-form form))))
+                                                        ast))))))))))

--- a/src/walker.lisp
+++ b/src/walker.lisp
@@ -1,0 +1,65 @@
+(in-package :check-it)
+
+(defparameter *test-block* (gensym "TEST-BLOCK")
+  "The symbol used to name the blocks for the tests.")
+
+(def layer with-tests)
+
+(def form-class generator-form ()
+  ((expr nil :ast-link t)
+   (gensym (gensym "GENERATOR-VALUE"))))
+
+(def form-class check-that-form ()
+  ((value nil :ast-link t)))
+
+(def (walker :in with-tests) generator
+  (with-form-object (form 'generator-form -parent-)
+    (setf (expr-of form)
+          ;; All of the nested generators should be left alone.
+          (with-inactive-layers (with-tests)
+            (hu.dwim.walker::recurse -form-)))))
+
+(def unwalker generator-form (gensym)
+  gensym)
+
+(def (walker :in with-tests) check-that
+  (with-form-object (form 'check-that-form -parent-)
+    (setf (value-of form) (hu.dwim.walker::recurse (cadr -form-)))))
+
+(def unwalker check-that-form (value)
+  `(return-from ,*test-block* ,(unwalk-form value)))
+
+;; Substitute every check-that-form that remains with the gensym used
+;; for it.
+(def macro with-tests (&body body &environment env)
+  (process-body `(progn ,@body) (make-walk-environment env)))
+
+(def function process-body (body &optional env)
+  (with-active-layers (with-tests)
+    (let* ((ast (walk-form body :environment env))
+           (check-that-forms (collect-variable-references ast :type 'check-that-form))
+           (generator-forms (collect-variable-references ast :type 'generator-form))
+           (gensyms (mapcar #'gensym-of generator-forms))
+           (generator `(generator (tuple ,@(mapcar (compose #'unwalk-form #'expr-of) generator-forms)))))
+      (duplicate ast generator check-that-forms gensyms))))
+
+(def function duplicate (ast generator check-that-forms gensyms)
+  "Duplicates AST N times, with only a single, but different
+   check-that in each one. GENERATOR is the generator expression that
+   should be used for to generate all of the values. GENSYMS are the
+   symbols the values returned by GENERATOR should be bound to."
+  (once-only (generator)
+    `(progn ,@(loop with gargs = (gensym "ARGS")
+                    for check-that-form in check-that-forms
+                    collect `(check-it% ',(source-of check-that-form)
+                                        ,generator
+                                        (lambda (,gargs)
+                                          (block ,*test-block*
+                                            (destructuring-bind ,gensyms ,gargs
+                                              (declare (ignorable ,@gensyms))
+                                              ,(unwalk-form (substitute-ast-if
+                                                             (walk-form nil)
+                                                             (lambda (form)
+                                                               (and (typep form 'check-that-form)
+                                                                    (not (eq check-that-form form))))
+                                                             ast))))))))))


### PR DESCRIPTION
It makes it easier to bind generators to variables and run tests with
them. For example:

```
(with-generators ((x (integer)) 
                  (y (integer)))
  (check-that (= (+ x y) (+ x y)))
  ;; Case designed to fail.
  (check-that (= (+ x y) (+ x y 1))))
```

I plan on writing a more powerful version that would allow something such as the following:

```
(with-generators ((x (integer))
                  (y (integer)))
  (let ((result (+ x y)))
    (check-that (= result result))
    (check-that (= result (+ result 1)))))
```

I can think of no easy way to implement it except by using a code walker.
