### PR TITLE
Make it build with ASDF 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ script:
   - cl -e '(in-package :cl-user)'
        -e '(ql:quickload :check-it)'
        -e '(ql:quickload :check-it/test)'
-       -e '(check-it-test::run-tests-for-travis)'
+       -e '(check-it/test::run-tests-for-travis)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ install:
 script:
   - cl -e '(in-package :cl-user)'
        -e '(ql:quickload :check-it)'
-       -e '(ql:quickload :check-it-test)'
+       -e '(ql:quickload :check-it/test)'
        -e '(check-it-test::run-tests-for-travis)'

--- a/check-it.asd
+++ b/check-it.asd
@@ -6,8 +6,6 @@
   :author "Kyle Littler"
   :license "LLGPL"
   :description "A randomized property-based testing tool for Common Lisp."
-  :long-description
-  #.(read-file-string (subpathname *load-pathname* "README.md"))
   :homepage "https://github.com/DalekBaldwin/check-it"
   :version "0.1.0"
   :components
@@ -40,4 +38,4 @@
                          (:file "for-travis"))))
   :depends-on ("check-it"
                "fiasco")
-  :perform (test-op (op c) (symbol-call :check-it-test '#:run-all-tests)))
+  :perform (test-op (op c) (symbol-call :check-it/test '#:run-all-tests)))

--- a/check-it.asd
+++ b/check-it.asd
@@ -1,23 +1,18 @@
 ;;;; check-it.asd
 
-(defpackage :check-it-system
-  (:use :cl :asdf))
-(in-package :check-it-system)
-
-(defsystem :check-it
+(defsystem "check-it"
   :name "check-it"
   :serial t
   :author "Kyle Littler"
   :license "LLGPL"
   :description "A randomized property-based testing tool for Common Lisp."
   :long-description
-  #.(uiop:read-file-string
-     (uiop:subpathname *load-pathname* "README.md"))
+  #.(read-file-string (subpathname *load-pathname* "README.md"))
   :homepage "https://github.com/DalekBaldwin/check-it"
   :version "0.1.0"
   :components
   ((:static-file "check-it.asd")
-   (:module :src
+   (:module "src"
             :components ((:file "package")
                          (:file "util")
                          (:file "generators")
@@ -25,25 +20,21 @@
                          (:file "shrink")
                          (:file "check-it"))
             :serial t))
-  :depends-on (:alexandria :closer-mop :optima)
-  :in-order-to ((test-op (load-op :check-it-test)))
-  :perform (test-op :after (op c)
-                    (funcall
-                     (intern #.(string '#:run-all-tests)
-                             :check-it-test))))
+  :depends-on ("alexandria" "closer-mop" "optima")
+  :in-order-to ((test-op (test-op "check-it/test"))))
 
-(defsystem :check-it-test
-  :name "check-it-test"
+(defsystem "check-it/test"
   :serial t
   :author "Kyle Littler"
   :license "LLGPL"
   :description "Tests for check-it."
   :components
-  ((:module :test
+  ((:module "test"
             :components ((:file "package")
                          (:file "check-it-test")
                          (:file "deterministic-tests")
                          (:file "randomized-tests")
                          (:file "destructive-tests")
                          (:file "for-travis"))))
-  :depends-on (:check-it :stefil))
+  :depends-on ("check-it" "stefil")
+  :perform (test-op (op c) (symbol-call :check-it-test '#:run-all-tests)))

--- a/check-it.asd
+++ b/check-it.asd
@@ -20,7 +20,9 @@
                          (:file "shrink")
                          (:file "check-it"))
             :serial t))
-  :depends-on ("alexandria" "closer-mop" "optima")
+  :depends-on ("alexandria"
+               "closer-mop"
+               "optima")
   :in-order-to ((test-op (test-op "check-it/test"))))
 
 (defsystem "check-it/test"
@@ -36,5 +38,6 @@
                          (:file "randomized-tests")
                          (:file "destructive-tests")
                          (:file "for-travis"))))
-  :depends-on ("check-it" "stefil")
+  :depends-on ("check-it"
+               "fiasco")
   :perform (test-op (op c) (symbol-call :check-it-test '#:run-all-tests)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -14,7 +14,7 @@
 
            #:generator
            #:generate
-           
+
            #:regenerate
 
            #:int-generator
@@ -49,7 +49,7 @@
 
            #:def-generator
            #:def-genex-macro
-           
+
            #:wrap-test-for-error-reporting
            #:wrap-test-for-shrinking
 
@@ -61,7 +61,4 @@
 (in-package :check-it)
 
 (defparameter *system-directory*
-  (make-pathname
-   :directory
-   (pathname-directory
-    (asdf:system-definition-pathname "check-it"))))
+  (asdf:system-source-directory "check-it"))

--- a/test/check-it-test.lisp
+++ b/test/check-it-test.lisp
@@ -1,4 +1,4 @@
-(in-package :check-it-test)
+(in-package :check-it/test)
 
 #+nil
 (in-root-suite)

--- a/test/check-it-test.lisp
+++ b/test/check-it-test.lisp
@@ -1,5 +1,6 @@
 (in-package :check-it-test)
 
+#+nil
 (in-root-suite)
 
 (defun run-all-tests ()

--- a/test/destructive-tests.lisp
+++ b/test/destructive-tests.lisp
@@ -1,4 +1,4 @@
-(in-package :check-it-test)
+(in-package :check-it/test)
 
 #+nil
 (in-root-suite)

--- a/test/destructive-tests.lisp
+++ b/test/destructive-tests.lisp
@@ -1,7 +1,9 @@
 (in-package :check-it-test)
 
+#+nil
 (in-root-suite)
 
+#+nil
 (in-suite randomized-tests)
 
 ;;;; Test pattern: copy generated value, mutate value in cache, regenerate, and compare

--- a/test/deterministic-tests.lisp
+++ b/test/deterministic-tests.lisp
@@ -1,4 +1,4 @@
-(in-package :check-it-test)
+(in-package :check-it/test)
 
 #+nil
 (in-root-suite)

--- a/test/deterministic-tests.lisp
+++ b/test/deterministic-tests.lisp
@@ -1,7 +1,9 @@
 (in-package :check-it-test)
 
+#+nil
 (in-root-suite)
 
+#+nil
 (defsuite* deterministic-tests)
 
 (deftest test-int-shrink ()

--- a/test/for-travis.lisp
+++ b/test/for-travis.lisp
@@ -8,6 +8,8 @@
            (force-output t)
            (sleep 1)
            (uiop:quit -1))))
+    (fiasco:run-package-tests)
+    #+nil
     (handler-case
         (run-all-tests)
       ;; some Lisps appear not to use the condition's :report value,

--- a/test/for-travis.lisp
+++ b/test/for-travis.lisp
@@ -1,4 +1,4 @@
-(in-package :check-it-test)
+(in-package :check-it/test)
 
 (defun run-tests-for-travis ()
   (let ((*debugger-hook*
@@ -8,7 +8,7 @@
            (force-output t)
            (sleep 1)
            (uiop:quit -1))))
-    (fiasco:run-package-tests :package :check-it-test)
+    (fiasco:run-package-tests :package :check-it/test)
     #+nil
     (handler-case
         (run-all-tests)

--- a/test/for-travis.lisp
+++ b/test/for-travis.lisp
@@ -8,7 +8,7 @@
            (force-output t)
            (sleep 1)
            (uiop:quit -1))))
-    (fiasco:run-package-tests)
+    (fiasco:run-package-tests :package :check-it-test)
     #+nil
     (handler-case
         (run-all-tests)

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -1,6 +1,6 @@
 (in-package :cl-user)
 
-(fiasco:define-test-package :check-it-test
+(fiasco:define-test-package :check-it/test
   (:use :cl
         :check-it
         :fiasco
@@ -11,6 +11,6 @@
    #:deterministic-tests
    #:randomized-tests))
 
-(in-package :check-it-test)
+(in-package :check-it/test)
 
 (defparameter *system-directory* check-it::*system-directory*)

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -1,7 +1,11 @@
 (in-package :cl-user)
 
-(defpackage :check-it-test
-  (:use :cl :check-it :stefil :alexandria)
+(fiasco:define-test-package :check-it-test
+  (:use :cl
+        :check-it
+        :fiasco
+        :alexandria)
+  #+nil
   (:export
    #:run-all-tests
    #:deterministic-tests

--- a/test/randomized-tests.lisp
+++ b/test/randomized-tests.lisp
@@ -4,8 +4,10 @@
  :check-it-test
  (merge-pathnames "test/regression-cases.lisp" *system-directory*))
 
+#+nil
 (in-root-suite)
 
+#+nil
 (defsuite* randomized-tests)
 
 (deftest test-generator ()

--- a/test/randomized-tests.lisp
+++ b/test/randomized-tests.lisp
@@ -1,7 +1,7 @@
-(in-package :check-it-test)
+(in-package :check-it/test)
 
 (register-package-regression-file
- :check-it-test
+ :check-it/test
  (merge-pathnames "test/regression-cases.lisp" *system-directory*))
 
 #+nil


### PR DESCRIPTION
Don't use deprecated system-definition-pathname, but system-source-directory.

Refactor the .asd file to follow latest recommendations.
In particular, follow secondary system naming convention to avoid warning.