### PR TITLE
Fix test arg type when shrinking string-generator

### DIFF
--- a/src/shrink.lisp
+++ b/src/shrink.lisp
@@ -116,7 +116,9 @@
 ;;;; Generator shrinkers
 
 (defmethod shrink ((value string-generator) test)
-  (let ((shrunken (shrink-list (cached-str-list value) test)))
+  (let ((shrunken (shrink-list (cached-str-list value)
+                               (lambda (arg)
+                                 (funcall test (join-list arg))))))
     (setf (cached-value value) (join-list shrunken))))
 
 (defmethod shrink ((value int-generator) test)

--- a/test/deterministic-tests.lisp
+++ b/test/deterministic-tests.lisp
@@ -15,6 +15,16 @@
        (is (equal (shrink (make-list size :initial-element nil) #'list-tester)
                   '(nil nil nil nil nil)))))
 
+(deftest test-string-generator-shrink-type ()
+  (let ((g (generator (string :min-length 1)))
+        (stringp-arg))
+    (generate g)
+    (let ((shrunken (shrink g (lambda (arg)
+                                (pushnew (stringp arg) stringp-arg)
+                                nil))))
+      (is (stringp shrunken))
+      (is (equal '(t) stringp-arg)))))
+
 (deftest test-struct-slot-names ()
   (let ((test-struct (make-a-struct :a-slot 5 :another-slot 5)))
     (is (equalp (check-it::struct-slot-names test-struct)


### PR DESCRIPTION
Fixes shrinking of string-generator by taking care to pass a string (rather than the list from SHRINK-LIST) to the test.