### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/check-it.asd
+++ b/check-it.asd
@@ -1,11 +1,6 @@
 ;;;; check-it.asd
 
-(defpackage :check-it-system
-  (:use :cl :asdf))
-(in-package :check-it-system)
-
 (defsystem :check-it
-  :name "check-it"
   :serial t
   :author "Kyle Littler"
   :license "LLGPL"
@@ -26,14 +21,9 @@
                          (:file "check-it"))
             :serial t))
   :depends-on (:alexandria :closer-mop :optima)
-  :in-order-to ((test-op (load-op :check-it-test)))
-  :perform (test-op :after (op c)
-                    (funcall
-                     (intern #.(string '#:run-all-tests)
-                             :check-it-test))))
+  :in-order-to ((test-op (test-op :check-it/test))))
 
-(defsystem :check-it-test
-  :name "check-it-test"
+(defsystem :check-it/test
   :serial t
   :author "Kyle Littler"
   :license "LLGPL"
@@ -46,4 +36,6 @@
                          (:file "randomized-tests")
                          (:file "destructive-tests")
                          (:file "for-travis"))))
-  :depends-on (:check-it :stefil))
+  :depends-on (:check-it :stefil)
+  :perform (test-op (op c)
+             (symbol-call :check-it-test :run-all-tests)))


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
